### PR TITLE
Adding XLS UI elements for s3 source

### DIFF
--- a/docs/S3-batchsource.md
+++ b/docs/S3-batchsource.md
@@ -19,14 +19,27 @@ the credentials does not need to be provided.
 **Path:** Path to read from. For example, s3a://<bucket>/path/to/input
 
 **Format:** Format of the data to read.
-The format must be one of 'avro', 'blob', 'csv', 'delimited', 'json', 'parquet', 'text', or 'tsv'.
+The format must be one of 'avro', 'blob', 'csv', 'delimited', 'json', 'parquet', 'text', 'tsv' or 'xls'.
 If the format is 'blob', every input file will be read into a separate record.
 The 'blob' format also requires a schema that contains a field named 'body' of type 'bytes'.
 If the format is 'text', the schema must contain a field named 'body' of type 'string'.
 
+**Sample Size:** The maximum number of rows that will get investigated for automatic data type detection.
+The default value is 1000. This is only used when the format is 'xls'.
+
+**Override:** A list of columns with the corresponding data types for whom the automatic data type detection gets
+skipped. This is only used when the format is 'xls'.
+
+**Terminate Reading After Empty Row:** Specify whether to stop reading after encountering the first empty row. Defaults to false. When false the reader will read all rows in the sheet. This is only used when the format is 'xls'.
+
+**Select Sheet Using:** Select the sheet by name or number. Default is 'Sheet Number'. This is only used when the format is 'xls'.
+
+**Sheet Value:** The name/number of the sheet to read from. If not specified, the first sheet will be read.
+Sheet Numbers are 0 based, ie first sheet is 0. This is only used when the format is 'xls'.
+
 **Delimiter:** Delimiter to use when the format is 'delimited'. This will be ignored for other formats.
 
-**Use First Row as Header:** Whether to use first row as header. Supported formats are 'text', 'csv', 'tsv', 'delimited'.
+**Use First Row as Header:** Whether to use first row as header. Supported formats are 'text', 'csv', 'tsv', 'delimited', 'xls'.
 
 **Authentication Method:** Authentication method to access S3. The default value is Access Credentials.
 IAM can only be used if the plugin is run in an AWS environment, such as on EMR.

--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>6.11.0-SNAPSHOT</cdap.version>
-    <cdap.plugin.version>2.13.0-SNAPSHOT</cdap.plugin.version>
+    <cdap.version>6.11.0</cdap.version>
+    <cdap.plugin.version>2.13.0</cdap.plugin.version>
     <data.pipeline.parent>system:cdap-data-pipeline[6.11.0-SNAPSHOT, 7.0.0-SNAPSHOT)</data.pipeline.parent>
     <data.stream.parent>system:cdap-data-streams[6.11.0-SNAPSHOT, 7.0.0-SNAPSHOT)</data.stream.parent>
     <hadoop.version>3.3.6</hadoop.version>

--- a/src/main/java/io/cdap/plugin/aws/s3/source/S3BatchSource.java
+++ b/src/main/java/io/cdap/plugin/aws/s3/source/S3BatchSource.java
@@ -147,6 +147,9 @@ public class S3BatchSource extends AbstractFileSource<S3BatchSource.S3BatchConfi
     public static final String NAME_PATH = "path";
     private static final String NAME_FILE_SYSTEM_PROPERTIES = "fileSystemProperties";
     private static final String NAME_DELIMITER = "delimiter";
+    private static final String NAME_SHEET = "sheet";
+    private static final String NAME_SHEET_VALUE = "sheetValue";
+    private static final String NAME_TERMINATE_IF_EMPTY_ROW = "terminateIfEmptyRow";
 
     private static final Gson GSON = new Gson();
     private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() { }.getType();
@@ -179,6 +182,36 @@ public class S3BatchSource extends AbstractFileSource<S3BatchSource.S3BatchConfi
       "credentials are incorrect. When true, the accuracy of the credentials will be evaluated and validation will " +
       "fail, if credentials are incorrect. The default value is false.")
     private Boolean verifyCredentials;
+
+    @Macro
+    @Nullable
+    @Description("The maximum number of rows that will get investigated for automatic data type detection.")
+    private Long sampleSize;
+
+    @Macro
+    @Nullable
+    @Description("A list of columns with the corresponding data types for whom the automatic data type detection gets" +
+            " skipped.")
+    private String override;
+
+    @Name(NAME_SHEET)
+    @Macro
+    @Nullable
+    @Description("Select the sheet by name or number. Default is 'Sheet Number'.")
+    private String sheet;
+
+    @Name(NAME_SHEET_VALUE)
+    @Macro
+    @Nullable
+    @Description("The name/number of the sheet to read from. If not specified, the first sheet will be read." +
+            "Sheet Numbers are 0 based, ie first sheet is 0.")
+    private String sheetValue;
+
+    @Name(NAME_TERMINATE_IF_EMPTY_ROW)
+    @Macro
+    @Nullable
+    @Description("Specify whether to stop reading after encountering the first empty row. Defaults to false.")
+    private String terminateIfEmptyRow;
 
     private S3BatchConfig(String path, @Nullable S3ConnectorConfig connection, String fileSystemProperties,
                           Boolean verifyCredentials) {

--- a/widgets/S3-batchsource.json
+++ b/widgets/S3-batchsource.json
@@ -120,7 +120,8 @@
               "json",
               "parquet",
               "text",
-              "tsv"
+              "tsv",
+              "xls"
             ],
             "default": "text"
           },
@@ -133,6 +134,36 @@
             ],
             "missing-required-fields-message": "Please provide path field",
             "plugin-method": "getSchema"
+          }
+        },
+        {
+          "widget-type": "number",
+          "label": "Sample Size",
+          "name": "sampleSize",
+          "widget-attributes": {
+            "default": "1000",
+            "minimum": "1"
+          }
+        },
+        {
+          "widget-type": "keyvalue-dropdown",
+          "label": "Override",
+          "name": "override",
+          "widget-attributes": {
+            "key-placeholder": "Field Name",
+            "value-placeholder": "Data Type",
+            "dropdownOptions": [
+              "boolean",
+              "bytes",
+              "double",
+              "float",
+              "int",
+              "long",
+              "string",
+              "date",
+              "time",
+              "timestamp"
+            ]
           }
         },
         {
@@ -173,6 +204,42 @@
               "value": "false",
               "label": "False"
             }
+          }
+        },
+        {
+          "widget-type": "toggle",
+          "label": "Terminate Reading After Empty Row",
+          "name": "terminateIfEmptyRow",
+          "widget-attributes": {
+            "default": "false",
+            "on": {
+              "value": "true",
+              "label": "True"
+            },
+            "off": {
+              "value": "false",
+              "label": "False"
+            }
+          }
+        },
+        {
+          "widget-type": "select",
+          "label": "Select Sheet Using",
+          "name": "sheet",
+          "widget-attributes": {
+            "values": [
+              "Sheet Name",
+              "Sheet Number"
+            ],
+            "default": "Sheet Number"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Sheet Value",
+          "name": "sheetValue",
+          "widget-attributes": {
+            "default": "0"
           }
         }
       ]
@@ -674,11 +741,44 @@
     {
       "name": "skipHeader",
       "condition": {
-        "expression": "format == 'delimited' || format == 'csv' || format == 'tsv'"
+        "expression": "format == 'delimited' || format == 'csv' || format == 'tsv' || format == 'xls'"
       },
       "show": [
         {
           "name": "skipHeader"
+        }
+      ]
+    },
+    {
+      "name": "sheet",
+      "condition": {
+        "expression": "format == 'xls'"
+      },
+      "show": [
+        {
+          "name": "sheet"
+        }
+      ]
+    },
+    {
+      "name": "sheetValue",
+      "condition": {
+        "expression": "format == 'xls'"
+      },
+      "show": [
+        {
+          "name": "sheetValue"
+        }
+      ]
+    },
+    {
+      "name": "terminateIfEmptyRow",
+      "condition": {
+        "expression": "format == 'xls'"
+      },
+      "show": [
+        {
+          "name": "terminateIfEmptyRow"
         }
       ]
     }


### PR DESCRIPTION
## Adding XLS UI elements for s3 source

Jira : [Plugin-1730](https://cdap.atlassian.net/browse/PLUGIN-1730)

### Description
This PR adds UI element required for https://github.com/cdapio/hydrator-plugins/pull/1835 in `S3 Source`.
Ref : XLS Support PR https://github.com/cdapio/hydrator-plugins/pull/1835

### Added Fields 
- Sample Size
- Override
- Terminate If Empty Row
- Select Sheet Using
- Sheet Value

A filter is used to show XLS specific values  `Terminate If Empty Row` , `Select Sheet Using`, `Sheet Value` only when format `XLS` is selected.


### Preview
![image](https://github.com/cloudsufi/amazon-s3-plugins/assets/122770897/9d8e7110-dd2c-465b-8f07-3f23d0a4a354)

